### PR TITLE
add shared calendar delete screen UI

### DIFF
--- a/lib/features/calendar/presentation/views/shared/shared_calendar_list_screen.dart
+++ b/lib/features/calendar/presentation/views/shared/shared_calendar_list_screen.dart
@@ -1,142 +1,211 @@
-import 'package:flutter/material.dart';
+import 'dart:ui';
 
+import 'package:flutter/material.dart';
 import '../../widgets/duty_table_appbar.dart';
 
-class SharedCalendarListScreen extends StatelessWidget {
-  /// 공유 캘린더 목록 화면
+class SharedCalendarListScreen extends StatefulWidget {
   const SharedCalendarListScreen({super.key});
 
   @override
-  Widget build(BuildContext context) {
-    return _SharedCalendarListScreen();
-  }
+  State<SharedCalendarListScreen> createState() =>
+      _SharedCalendarListScreenState();
 }
 
-class _SharedCalendarListScreen extends StatelessWidget {
-  const _SharedCalendarListScreen({super.key});
+class _SharedCalendarListScreenState extends State<SharedCalendarListScreen> {
+  bool deleteMode = false; // 삭제 모드 ON/OFF
+  bool isSelected = false; // 카드 체크 상태
+  bool isAdmin = false;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Colors.white,
-      appBar: DutyTableAppBar(),
+      appBar: DutyTableAppBar(
+        deleteMode: deleteMode,
+        onDeletePressed: () {
+          setState(() {
+            deleteMode = !deleteMode;
+          });
+        },
+      ),
       body: Padding(
         padding: const EdgeInsets.symmetric(horizontal: 20.0),
         child: Column(
           children: [
             const SizedBox(height: 10),
 
-            Stack(
-              clipBehavior: Clip.none,
-              children: [
-                Card(
-                  elevation: 3,
-                  color: Colors.white,
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(12),
-                    side: BorderSide(color: Colors.grey, width: 1),
-                  ),
-                  child: Container(
-                    padding: const EdgeInsets.all(16),
-                    width: double.infinity,
-                    child: Row(
-                      children: [
-                        // LEFT: 아이콘 박스
-                        Container(
-                          width: 60,
-                          height: 60,
-                          decoration: BoxDecoration(
-                            color: const Color(0xFF3A7BFF),
-                            borderRadius: BorderRadius.circular(16),
-                          ),
-                          child: Image.asset(
-                            "assets/images/calendar_logo.png",
-                            fit: BoxFit.contain,
-                          ),
-                        ),
-
-                        const SizedBox(width: 16),
-
-                        // MIDDLE: 텍스트 영역
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              // 제목 + 멤버수 뱃지
-                              Row(
-                                children: [
-                                  Text(
-                                    "팀 프로젝트",
-                                    style: const TextStyle(
-                                      fontSize: 18,
-                                      fontWeight: FontWeight.w700,
-                                    ),
-                                  ),
-
-                                  const SizedBox(width: 8),
-
-                                  Container(
-                                    padding: const EdgeInsets.symmetric(
-                                      horizontal: 12,
-                                      vertical: 2,
-                                    ),
-                                    decoration: BoxDecoration(
-                                      color: Colors.grey.shade200,
-                                      borderRadius: BorderRadius.circular(16),
-                                    ),
-                                    child: Text(
-                                      "99+명",
-                                      style: const TextStyle(
-                                        fontSize: 13,
-                                        fontWeight: FontWeight.w600,
-                                      ),
-                                    ),
-                                  ),
-                                ],
-                              ),
-
-                              const SizedBox(height: 6),
-
-                              // 다음 일정
-                              Text(
-                                "다음 일정: 12월 5일",
-                                style: TextStyle(
-                                  fontSize: 14,
-                                  color: Colors.grey.shade600,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-
-                        const SizedBox(width: 16),
-
-                        // RIGHT: 읽지 않은 메시지
-                        Container(
-                          width: 42,
-                          height: 42,
-                          decoration: const BoxDecoration(
-                            color: Colors.red,
-                            shape: BoxShape.circle,
-                          ),
-                          alignment: Alignment.center,
-                          child: Text(
-                            "99+",
-                            style: const TextStyle(
-                              color: Colors.white,
-                              fontWeight: FontWeight.bold,
-                            ),
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ],
+            _buildCalendarCard(
+              title: "팀 프로젝트",
+              deletable: true,
+              isAdmin: false,
             ),
+
+            const SizedBox(height: 12),
+
+            _buildCalendarCard(title: "부서 공지", deletable: false, isAdmin: true),
           ],
         ),
       ),
+    );
+  }
+
+  Widget _buildCalendarCard({
+    required String title,
+    required bool deletable,
+    required bool isAdmin,
+  }) {
+    final applyBlur = deleteMode && isAdmin;
+
+    return Stack(
+      children: [
+        Card(
+          elevation: 2,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(12),
+            side: BorderSide(
+              color: isSelected && !applyBlur ? Colors.red : Colors.grey,
+              width: isSelected && !applyBlur ? 2 : 1,
+            ),
+          ),
+          child: Container(
+            padding: const EdgeInsets.all(16),
+            width: double.infinity,
+            child: Row(
+              children: [
+                // LEFT ICON
+                Container(
+                  width: 40,
+                  height: 40,
+                  decoration: BoxDecoration(
+                    color: const Color(0xFF3A7BFF),
+                    borderRadius: BorderRadius.circular(16),
+                  ),
+                  child: Image.asset(
+                    "assets/images/calendar_logo.png",
+                    fit: BoxFit.contain,
+                  ),
+                ),
+
+                const SizedBox(width: 16),
+
+                // MIDDLE TITLE & DATE
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // 제목 + 멤버수 뱃지
+                      Row(
+                        children: [
+                          Text(
+                            "팀 프로젝트",
+                            style: const TextStyle(
+                              fontSize: 14,
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          const SizedBox(width: 8),
+                          Container(
+                            padding: const EdgeInsets.symmetric(
+                              horizontal: 12,
+                              vertical: 2,
+                            ),
+                            decoration: BoxDecoration(
+                              color: Colors.grey.shade200,
+                              borderRadius: BorderRadius.circular(16),
+                            ),
+                            child: Text(
+                              "99+명",
+                              style: const TextStyle(
+                                fontSize: 10,
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+
+                      const SizedBox(height: 6),
+
+                      // 다음 일정
+                      Text(
+                        "다음 일정: 12월 5일",
+                        style: TextStyle(
+                          fontSize: 12,
+                          color: Colors.grey.shade600,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+                const SizedBox(width: 16),
+
+                // RIGHT SIDE
+                if (!deleteMode)
+                  // 기본 뱃지
+                  Container(
+                    width: 42,
+                    height: 42,
+                    decoration: const BoxDecoration(
+                      color: Colors.red,
+                      shape: BoxShape.circle,
+                    ),
+                    alignment: Alignment.center,
+                    child: const Text(
+                      "99+",
+                      style: TextStyle(
+                        color: Colors.white,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  )
+                else
+                  // 삭제 모드일 때
+                  !isAdmin
+                      ? Checkbox(
+                          value: isSelected,
+                          activeColor: Colors.red,
+                          onChanged: (value) {
+                            setState(() {
+                              isSelected = value ?? false;
+                            });
+                          },
+                        )
+                      : Container(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 10,
+                            vertical: 4,
+                          ),
+                          decoration: BoxDecoration(
+                            color: Colors.grey.shade300,
+                            borderRadius: BorderRadius.circular(16),
+                          ),
+                          child: const Text(
+                            "삭제 불가",
+                            style: TextStyle(
+                              fontSize: 12,
+                              fontWeight: FontWeight.w600,
+                              color: Colors.black54,
+                            ),
+                          ),
+                        ),
+              ],
+            ),
+          ),
+        ),
+
+        if (applyBlur)
+          Positioned.fill(
+            child: IgnorePointer(
+              child: Container(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                decoration: BoxDecoration(
+                  borderRadius: BorderRadius.circular(16),
+                  color: Colors.white.withOpacity(0.6), // 흐릿한 흰색 오버레이
+                ),
+              ),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/lib/features/calendar/presentation/widgets/duty_table_appbar.dart
+++ b/lib/features/calendar/presentation/widgets/duty_table_appbar.dart
@@ -6,8 +6,15 @@ import 'package:go_router/go_router.dart';
 ///  2. 현재 앱 바가 두개라 헷갈릴 수도 있음
 
 class DutyTableAppBar extends StatelessWidget implements PreferredSizeWidget {
+  final bool deleteMode;
+  final VoidCallback? onDeletePressed;
+
   /// 공유 캘린더 앱 바
-  const DutyTableAppBar({super.key});
+  const DutyTableAppBar({
+    super.key,
+    required this.deleteMode,
+    this.onDeletePressed,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -50,51 +57,63 @@ class DutyTableAppBar extends StatelessWidget implements PreferredSizeWidget {
           const Spacer(),
 
           // RIGHT: 캘린더 추가, 알림, 캘린더 삭제
-          Row(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Container(
-                width: 42,
-                height: 42,
-                decoration: const BoxDecoration(
-                  color: Color(0xFF3A7BFF),
-                  shape: BoxShape.circle,
-                ),
-                child: GestureDetector(
-                  onTap: () => context.push("/shared/add"),
-                  child: Icon(Icons.add, color: Colors.white),
-                ),
-              ),
-
-              const SizedBox(width: 16),
-
-              GestureDetector(
-                onTap: () => context.push("/notification"),
-                child: Stack(
-                  clipBehavior: Clip.none,
+          deleteMode
+              ? Row(
+                  mainAxisSize: MainAxisSize.min,
                   children: [
-                    const Icon(Icons.notifications_none, size: 26),
-                    Positioned(
-                      right: -1,
-                      top: -1,
-                      child: Container(
-                        width: 10,
-                        height: 10,
-                        decoration: const BoxDecoration(
-                          color: Colors.red,
-                          shape: BoxShape.circle,
-                        ),
+                    GestureDetector(onTap: onDeletePressed, child: Text("취소")),
+                    const SizedBox(width: 16),
+                    Text("삭제"),
+                  ],
+                )
+              : Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Container(
+                      width: 42,
+                      height: 42,
+                      decoration: const BoxDecoration(
+                        color: Color(0xFF3A7BFF),
+                        shape: BoxShape.circle,
                       ),
+                      child: GestureDetector(
+                        onTap: () => context.push("/shared/add"),
+                        child: Icon(Icons.add, color: Colors.white),
+                      ),
+                    ),
+
+                    const SizedBox(width: 16),
+
+                    GestureDetector(
+                      onTap: () => context.push("/notification"),
+                      child: Stack(
+                        clipBehavior: Clip.none,
+                        children: [
+                          const Icon(Icons.notifications_none, size: 26),
+                          Positioned(
+                            right: -1,
+                            top: -1,
+                            child: Container(
+                              width: 10,
+                              height: 10,
+                              decoration: const BoxDecoration(
+                                color: Colors.red,
+                                shape: BoxShape.circle,
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+
+                    const SizedBox(width: 16),
+
+                    GestureDetector(
+                      onTap: onDeletePressed,
+                      child: const Icon(Icons.delete_outline, size: 26),
                     ),
                   ],
                 ),
-              ),
-
-              const SizedBox(width: 16),
-
-              const Icon(Icons.delete_outline, size: 26),
-            ],
-          ),
         ],
       ),
     );


### PR DESCRIPTION
## 이슈 번호
#17 

## UI

1. 공유 캘린더 방장일 경우
  - 캘린더 목록 카드 오른쪽 상단 삭제 불가 텍스트 추가 및 카드 배경색 흐릿하게 추가

2. 공유 캘린더 방장이 아닐 경우
  - 캘린더 목록 카드 오른쪽 상단 체크 박스 및 선택 시 빨간색 카드 테두리 추가

3. 취소 클릭 시 선택한 캘린더 목록 풀리고 원상 복귀