### PR TITLE
bugfix calendar delete after calendar list refresh

### DIFF
--- a/lib/features/calendar/presentation/views/setting/widgets/delete_button_section.dart
+++ b/lib/features/calendar/presentation/views/setting/widgets/delete_button_section.dart
@@ -31,14 +31,8 @@ class DeleteButtonSection extends StatelessWidget {
                         confirmColor: AppColors.danger(context),
                         onConfirm: () async {
                           await viewModel.deleteCalendar();
-                          context.go(
-                            '/shared',
-                            extra: {
-                              'refresh': true,
-                              'signalId': DateTime.now().millisecondsSinceEpoch
-                                  .toString(),
-                            },
-                          );
+                          context.pop();
+                          context.pop();
                         },
                       );
                     },
@@ -49,14 +43,8 @@ class DeleteButtonSection extends StatelessWidget {
                     confirmColor: AppColors.danger(context),
                     onConfirm: () async {
                       await viewModel.outCalendar();
-                      context.go(
-                        '/shared',
-                        extra: {
-                          'refresh': true,
-                          'signalId': DateTime.now().millisecondsSinceEpoch
-                              .toString(),
-                        },
-                      );
+                      context.pop();
+                      context.pop();
                     },
                   );
           },


### PR DESCRIPTION
# 이슈번호
#127 

## 주요내용

- 캘린더 삭제, 나가기 후 캘린더 목록 새로고침