### PR TITLE
add feat image picker option on calendar edit screen

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -37,6 +37,10 @@
 	<string>$(FLUTTER_BUILD_NUMBER)</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>지도 기능을 안정적으로 표시하고 필요한 경우 현재 위치 기반 서비스를 제공하기 위해 위치 정보 접근 권한이 필요합니다.</string>
+
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
 	<key>UIBackgroundModes</key>
@@ -58,11 +62,6 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
-	<key>UISupportedInterfaceOrientations~ipad</key>
-	<array>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
-		<string>UIInterfaceOrientationPortrait</string>
-	</array>
-</dict>
+
+	</dict>
 </plist>

--- a/lib/features/calendar/data/models/calendar_member_model.dart
+++ b/lib/features/calendar/data/models/calendar_member_model.dart
@@ -31,4 +31,33 @@ class CalendarMemberModel {
       profileUrl: profileUrl,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'calendar_id': calendar_id,
+      'user_id': user_id,
+      'is_admin': is_admin,
+      'last_read_at': last_read_at,
+      'nickname': nickname,
+      'profileUrl': profileUrl,
+    };
+  }
+
+  CalendarMemberModel copyWith({
+    int? calendar_id,
+    String? user_id,
+    bool? is_admin,
+    DateTime? last_read_at,
+    String? nickname,
+    String? profileUrl,
+  }) {
+    return CalendarMemberModel(
+      calendar_id: calendar_id ?? this.calendar_id,
+      user_id: user_id ?? this.user_id,
+      is_admin: is_admin ?? this.is_admin,
+      last_read_at: last_read_at ?? this.last_read_at,
+      nickname: nickname ?? this.nickname,
+      profileUrl: profileUrl,
+    );
+  }
 }

--- a/lib/features/calendar/data/models/calendar_model.dart
+++ b/lib/features/calendar/data/models/calendar_model.dart
@@ -54,4 +54,44 @@ class CalendarModel {
       ownerProfileUrl: ownerProfileUrl,
     );
   }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'type': type,
+      'user_id': user_id,
+      'ownerNickname': ownerNickname,
+      'title': title,
+      'description': description,
+      'imageURL': imageURL,
+      'calendarMemberModel': calendarMemberModel
+          ?.map((e) => e.toJson())
+          .toList(),
+      'ownerProfileUrl': ownerProfileUrl,
+    };
+  }
+
+  CalendarModel copyWith({
+    int? id,
+    String? type,
+    String? user_id,
+    String? ownerNickname,
+    String? ownerProfileUrl,
+    String? title,
+    String? description,
+    String? imageURL,
+    List<CalendarMemberModel>? calendarMemberModel,
+  }) {
+    return CalendarModel(
+      id: id ?? this.id,
+      type: type ?? this.type,
+      user_id: user_id ?? this.user_id,
+      ownerNickname: ownerNickname ?? this.ownerNickname,
+      ownerProfileUrl: ownerProfileUrl ?? this.ownerProfileUrl,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      imageURL: imageURL,
+      calendarMemberModel: calendarMemberModel ?? this.calendarMemberModel,
+    );
+  }
 }

--- a/lib/features/calendar/presentation/viewmodels/calendar_edit_view_model.dart
+++ b/lib/features/calendar/presentation/viewmodels/calendar_edit_view_model.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:dutytable/features/calendar/data/datasources/calendar_data_source.dart';
 import 'package:dutytable/features/calendar/data/models/calendar_model.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 
@@ -26,20 +26,23 @@ class CalendarEditViewModel extends ChangeNotifier {
   TextEditingController get descController => _descController;
 
   /// 캘린더 데이터(private)
+  late final CalendarModel _initialCalendar; // 초기 데이터 값
   late CalendarModel _calendar;
 
   /// 캘린더 데이터(public)
+  CalendarModel get initialCalendar => _initialCalendar; // 초기 데이터 값
   CalendarModel get calendar => _calendar;
 
   // 이미지 피커로 갤러리에서 사진 가져오기
-  File? _image;
-  File? get image => _image;
+  File? _newImage;
+  File? get newImage => _newImage;
   final ImagePicker picker = ImagePicker();
 
   /// 캘린더 수정 뷰모델
   CalendarEditViewModel({CalendarModel? initialCalendarData}) {
     if (initialCalendarData != null) {
       _calendar = initialCalendarData;
+      _initialCalendar = initialCalendarData; // 초기 상태 저장
     }
   }
 
@@ -51,26 +54,88 @@ class CalendarEditViewModel extends ChangeNotifier {
     );
   }
 
-  //이미지를 가져오기
-  Future getImage() async {
+  /// 이미지 옵션 선택
+  Future<void> pickImage(BuildContext context) async {
+    showModalBottomSheet(
+      context: context,
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (context) {
+        return SafeArea(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              ListTile(
+                leading: const Icon(Icons.camera_alt),
+                title: const Text("사진 촬영"),
+                onTap: () async {
+                  Navigator.pop(context);
+                  _pickProfileImageCamera();
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.photo_library),
+                title: const Text("앨범에서 선택"),
+                onTap: () async {
+                  Navigator.pop(context);
+                  _pickProfileImageAlbum();
+                },
+              ),
+              ListTile(
+                leading: const Icon(Icons.no_photography_outlined),
+                title: const Text("이미지 삭제"),
+                onTap: () async {
+                  Navigator.pop(context);
+                  _deleteImage();
+                },
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  /// 카메라에서 이미지를 가져오기
+  Future<void> _pickProfileImageCamera() async {
+    // 카메라에서 선택된 이미지
+    final XFile? pickedFile = await picker.pickImage(
+      source: ImageSource.camera,
+    );
+    if (pickedFile != null) {
+      _newImage = File(pickedFile.path); //이미지 가져와서 _image에 로컬 경로 저장
+    }
+    notifyListeners();
+  }
+
+  /// 갤러리에서 이미지를 가져오기
+  Future<void> _pickProfileImageAlbum() async {
     // 갤러리에서 선택된 이미지
     final XFile? pickedFile = await picker.pickImage(
       source: ImageSource.gallery,
     );
     if (pickedFile != null) {
-      _image = File(pickedFile.path); //이미지 가져와서 _image에 로컬 경로 저장
+      _newImage = File(pickedFile.path); //이미지 가져와서 _image에 로컬 경로 저장
     }
+    notifyListeners();
+  }
+
+  /// 이미지 지우기
+  Future<void> _deleteImage() async {
+    _newImage = null;
+    _calendar = _calendar.copyWith(imageURL: null);
     notifyListeners();
   }
 
   /// 선택한 이미지 supabase storage 에 저장
   Future<String?> _uploadCalendarImage() async {
-    if (_image == null) return null;
+    if (_newImage == null) return null;
 
     final user = supabase.auth.currentUser;
     if (user == null) throw Exception('User not authenticated');
 
-    final file = _image!;
+    final file = _newImage!;
     final extension = file.path.split('.').last;
     final filePath =
         'calendar-images/${user.id}/${DateTime.now().millisecondsSinceEpoch}.$extension';
@@ -88,14 +153,21 @@ class CalendarEditViewModel extends ChangeNotifier {
 
   /// 캘린더 정보 업데이트
   Future<bool> updateCalendarInfo() async {
-    final imageUrl = await _uploadCalendarImage();
+    String? finalImageUrl;
+
+    if (_newImage != null) {
+      finalImageUrl = await _uploadCalendarImage();
+    } else {
+      finalImageUrl = _calendar.imageURL;
+    }
 
     final bool result = await CalendarDataSource.instance.updateCalendarInfo(
       _titleController.text,
       _descController.text,
-      imageUrl ?? calendar.imageURL,
+      finalImageUrl,
       _calendar.id,
     );
+
     return result;
   }
 

--- a/lib/features/calendar/presentation/viewmodels/calendar_edit_view_model.dart
+++ b/lib/features/calendar/presentation/viewmodels/calendar_edit_view_model.dart
@@ -138,7 +138,7 @@ class CalendarEditViewModel extends ChangeNotifier {
     final file = _newImage!;
     final extension = file.path.split('.').last;
     final filePath =
-        'calendar-images/${user.id}/${DateTime.now().millisecondsSinceEpoch}.$extension';
+        'calendar-images/${_calendar.id}/${DateTime.now().millisecondsSinceEpoch}.$extension';
 
     await supabase.storage
         .from('calendar-images')

--- a/lib/features/calendar/presentation/views/edit/widgets/calendar_edit_body.dart
+++ b/lib/features/calendar/presentation/views/edit/widgets/calendar_edit_body.dart
@@ -29,11 +29,11 @@ class CalendarEditBody extends StatelessWidget {
             children: [
               GestureDetector(
                 onTap: () {
-                  viewModel.getImage();
+                  viewModel.pickImage(context);
                 },
                 child: CustomCalendarImageBox(
-                  imageUrl: viewModel.image != null
-                      ? viewModel.image!.path
+                  imageUrl: viewModel.newImage != null
+                      ? viewModel.newImage!.path
                       : viewModel.calendar.imageURL,
                 ),
               ),

--- a/lib/features/calendar/presentation/views/edit/widgets/edit_button_section.dart
+++ b/lib/features/calendar/presentation/views/edit/widgets/edit_button_section.dart
@@ -11,10 +11,22 @@ class EditButtonSection extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final isContentChange =
-        viewModel.titleController.text != viewModel.calendar.title ||
-        viewModel.descController.text != viewModel.calendar.description ||
-        viewModel.image?.path != viewModel.calendar.imageURL;
+    // 1. 텍스트 변경 여부
+    final bool isTitleChanged =
+        viewModel.titleController.text != viewModel.initialCalendar.title;
+    final bool isDescChanged =
+        viewModel.descController.text !=
+        (viewModel.initialCalendar.description ?? "");
+
+    // 2. 이미지 변경 여부 (핵심)
+    final bool isImageChanged =
+        viewModel.newImage != null || // 1) 새로운 파일을 선택했거나
+        viewModel.calendar.imageURL !=
+            viewModel.initialCalendar.imageURL; // 2) 기존 이미지를 삭제했거나(null이 됨)
+
+    // 3. 최종 변경 여부
+    final bool isContentChange =
+        isTitleChanged || isDescChanged || isImageChanged;
 
     return SafeArea(
       child: Padding(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+3
+version: 1.0.0+5
 
 environment:
   sdk: ^3.8.1

--- a/supabase/functions/push/index.ts
+++ b/supabase/functions/push/index.ts
@@ -94,7 +94,7 @@ Deno.serve(async (req) => {
 
   const { data: userData, error: userError } = await supabase
       .from('users')
-      .select('fcm_token')
+      .select('fcm_token, allowed_notification')
       .eq('id', targetUserId)
       .single()
 
@@ -105,6 +105,14 @@ Deno.serve(async (req) => {
         headers: { 'Content-Type': 'application/json' },
     })
   }
+
+if (!userData.allowed_notification) {
+  console.log(`User ${targetUserId} has notifications disabled. Skipping.`);
+  return new Response(JSON.stringify({ message: 'Notification is disabled by user.' }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+  })
+}
 
   const fcmToken = userData.fcm_token as string
 


### PR DESCRIPTION
# 이슈번호
#139 

## 주요내용

- 캘린더 수정 화면 이미지 피커 옵션 추가(카메라, 앨범 선택 가능 + 현재 이미지 삭제)
- 프로필 화면의 알림 설정에 따라 fcm 보내거나 안보내거나