### PR TITLE
Refactor/profile screen

### DIFF
--- a/lib/features/profile/presentation/viewmodels/profile_view_model.dart
+++ b/lib/features/profile/presentation/viewmodels/profile_view_model.dart
@@ -43,6 +43,10 @@ class ProfileViewmodel extends ChangeNotifier {
   /// 닉네임 중복 여부
   bool is_overlapping = true;
 
+  /// 온보딩 다시보기
+  bool _isShowOnboarding = false;
+  bool get isShowOnboarding => _isShowOnboarding;
+
   // 시작할때 닉네임,이메일,프로필 이미지 호출
   void _init() {
     fetchUser();
@@ -65,6 +69,12 @@ class ProfileViewmodel extends ChangeNotifier {
   //알림 토글
   void activeNotification() {
     is_active_notification = !is_active_notification;
+    notifyListeners();
+  }
+
+  // 온보딩 토글
+  void toggleOnboarding() {
+    _isShowOnboarding = !isShowOnboarding;
     notifyListeners();
   }
 

--- a/lib/features/profile/presentation/viewmodels/profile_view_model.dart
+++ b/lib/features/profile/presentation/viewmodels/profile_view_model.dart
@@ -11,6 +11,8 @@ import 'package:googleapis/calendar/v3.dart' as calendar;
 import 'package:http/http.dart' as http;
 import 'package:image_picker/image_picker.dart';
 
+import '../../../../core/services/device_resource_service.dart';
+
 class ProfileViewmodel extends ChangeNotifier {
   ProfileViewmodel() {
     _init();
@@ -21,6 +23,8 @@ class ProfileViewmodel extends ChangeNotifier {
 
   /// 닉네임 수정
   final nicknameController = TextEditingController();
+
+  final DeviceResourceService _resourceService = DeviceResourceService();
 
   /// 이메일
   String email = "";
@@ -46,6 +50,10 @@ class ProfileViewmodel extends ChangeNotifier {
   /// 온보딩 다시보기
   bool _isShowOnboarding = false;
   bool get isShowOnboarding => _isShowOnboarding;
+
+  /// 이미지 업로드
+  bool _isLoading = false;
+  bool get isLoading => _isLoading;
 
   // 시작할때 닉네임,이메일,프로필 이미지 호출
   void _init() {
@@ -120,21 +128,29 @@ class ProfileViewmodel extends ChangeNotifier {
   }
 
   // 이미지 피커로 갤러리에서 사진 가져오기
-  XFile? _image;
+  File? _image;
   final ImagePicker picker = ImagePicker();
 
-  //이미지를 가져오기
-  Future getImage(ImageSource imageSource) async {
-    // 갤러리에서 선택된 이미지
-    final XFile? pickedFile = await picker.pickImage(source: imageSource);
+  /// 이미지 선택
+  Future<void> pickProfileImage(ImageSource source) async {
+    final File? pickedFile = await _resourceService.pickImage(source);
     if (pickedFile != null) {
-      _image = XFile(pickedFile.path); //이미지 가져와서 _image에 로컬 경로 저장
+      _image = File(pickedFile.path);
     }
+    notifyListeners();
+  }
+
+  /// 이미지 삭제
+  Future<void> deleteImage() async {
+    _image = null;
     notifyListeners();
   }
 
   Future<void> upload() async {
     if (_image == null) return;
+
+    _isLoading = true;
+    notifyListeners();
 
     try {
       final fileToUpload = File(_image!.path);
@@ -145,6 +161,7 @@ class ProfileViewmodel extends ChangeNotifier {
 
       if (publicUrl != null) {
         await updateImage(user!.id, publicUrl);
+        _isLoading = false;
         notifyListeners();
       }
     } catch (e) {

--- a/lib/features/profile/presentation/views/profile_screen.dart
+++ b/lib/features/profile/presentation/views/profile_screen.dart
@@ -8,6 +8,8 @@ import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 
+import '../../../onboarding/presentation/views/onboarding_screen.dart';
+
 class ProfileScreen extends StatelessWidget {
   const ProfileScreen({super.key});
 
@@ -29,118 +31,125 @@ class _ProfileScreen extends StatelessWidget {
 
     return Consumer<ProfileViewmodel>(
       builder: (context, viewModel, child) {
-        return Scaffold(
-          backgroundColor: AppColors.background(context),
-          appBar: LogoActionsAppBar(
-            leftActions: Text(
-              "프로필",
-              style: TextStyle(
-                fontWeight: FontWeight.bold,
-                fontSize: 20,
-                color: AppColors.textMain(context),
-              ),
-            ),
-            rightActions: GestureDetector(
-              onTap: () {
-                //로그아웃 다이얼로그
-                showDialog(
-                  context: context,
-                  builder: (context) => CustomDialog(
-                    context,
-                    height: 240.0,
-                    iconBackgroundColor: const Color(0xFFDBE9FE),
-                    icon: Icons.logout_outlined,
-                    iconColor: AppColors.primaryBlue,
-                    title: "로그아웃",
-                    message: "정말 로그아웃 하시겠습니까?",
-                    allow: "로그아웃",
-                    onChangeSelected: () {
-                      viewModel.logout();
-                      context.pop();
-                      context.go('/login');
-                    },
-                    onClosed: () => context.pop(),
+        return Stack(
+          children: [
+            Scaffold(
+              backgroundColor: AppColors.background(context),
+              appBar: LogoActionsAppBar(
+                leftActions: Text(
+                  "프로필",
+                  style: TextStyle(
+                    fontWeight: FontWeight.bold,
+                    fontSize: 20,
+                    color: AppColors.textMain(context),
                   ),
-                );
-              },
-              child: Icon(Icons.logout, color: AppColors.iconSub(context)),
-            ),
-          ),
-          body: SafeArea(
-            child: ListView(
-              children: [
-                Column(
-                  children: [
-                    const SizedBox(height: 10),
+                ),
+                rightActions: GestureDetector(
+                  onTap: () {
+                    //로그아웃 다이얼로그
+                    showDialog(
+                      context: context,
+                      builder: (context) => CustomDialog(
+                        context,
+                        height: 240.0,
+                        iconBackgroundColor: const Color(0xFFDBE9FE),
+                        icon: Icons.logout_outlined,
+                        iconColor: AppColors.primaryBlue,
+                        title: "로그아웃",
+                        message: "정말 로그아웃 하시겠습니까?",
+                        allow: "로그아웃",
+                        onChangeSelected: () {
+                          viewModel.logout();
+                          context.pop();
+                          context.go('/login');
+                        },
+                        onClosed: () => context.pop(),
+                      ),
+                    );
+                  },
+                  child: Icon(Icons.logout, color: AppColors.iconSub(context)),
+                ),
+              ),
+              body: SafeArea(
+                child: SingleChildScrollView(
+                  child: Column(
+                    children: [
+                      const SizedBox(height: 10),
 
-                    // 프로필 섹션
-                    UserProfileSection(),
+                      // 프로필 섹션
+                      UserProfileSection(),
 
-                    // 버튼 섹션(동기화, 테마, 알림, 앱소개 다시보기)
-                    ProfileButtonSection(),
+                      // 버튼 섹션(동기화, 테마, 알림, 앱소개 다시보기)
+                      ProfileButtonSection(),
 
-                    // 회원탈퇴
-                    GestureDetector(
-                      onTap: () {
-                        showDialog(
-                          context: context,
-                          builder: (context) => CustomDialog(
-                            context,
-                            height: 280.0,
-                            iconBackgroundColor: isDarkMode
-                                ? const Color(0xFF451225)
-                                : const Color(0xFFFBE7F3),
-                            icon: Icons.warning,
-                            iconColor: AppColors.danger(context),
-                            title: "회원탈퇴",
-                            message: "정말 회원탈퇴 하시겠습니까?",
-                            allow: "회원탈퇴",
-                            announcement: Container(
-                              decoration: BoxDecoration(
-                                borderRadius: BorderRadius.circular(10),
-                                border: Border.all(
-                                  color: AppColors.warningBannerBorder(context),
-                                ),
-                                color: AppColors.warningBanner(context),
-                              ),
-                              child: SizedBox(
-                                width: 250,
-                                height: 50,
-                                child: Padding(
-                                  padding: const EdgeInsets.all(10.0),
-                                  child: Text(
-                                    "탈퇴 시 모든 데이터가 삭제되며 \n복구할 수 없습니다",
-                                    style: TextStyle(
-                                      fontSize: 10,
-                                      color: AppColors.textMain(context),
+                      // 회원탈퇴
+                      GestureDetector(
+                        onTap: () {
+                          showDialog(
+                            context: context,
+                            builder: (context) => CustomDialog(
+                              context,
+                              height: 280.0,
+                              iconBackgroundColor: isDarkMode
+                                  ? const Color(0xFF451225)
+                                  : const Color(0xFFFBE7F3),
+                              icon: Icons.warning,
+                              iconColor: AppColors.danger(context),
+                              title: "회원탈퇴",
+                              message: "정말 회원탈퇴 하시겠습니까?",
+                              allow: "회원탈퇴",
+                              announcement: Container(
+                                decoration: BoxDecoration(
+                                  borderRadius: BorderRadius.circular(10),
+                                  border: Border.all(
+                                    color: AppColors.warningBannerBorder(
+                                      context,
                                     ),
-                                    textAlign: TextAlign.center,
+                                  ),
+                                  color: AppColors.warningBanner(context),
+                                ),
+                                child: SizedBox(
+                                  width: 250,
+                                  height: 50,
+                                  child: Padding(
+                                    padding: const EdgeInsets.all(10.0),
+                                    child: Text(
+                                      "탈퇴 시 모든 데이터가 삭제되며 \n복구할 수 없습니다",
+                                      style: TextStyle(
+                                        fontSize: 10,
+                                        color: AppColors.textMain(context),
+                                      ),
+                                      textAlign: TextAlign.center,
+                                    ),
                                   ),
                                 ),
                               ),
+                              onChangeSelected: () {
+                                viewModel.deleteUser();
+                                context.pop();
+                                context.go('/login');
+                              },
+                              onClosed: () => context.pop(),
                             ),
-                            onChangeSelected: () {
-                              viewModel.deleteUser();
-                              context.pop();
-                              context.go('/login');
-                            },
-                            onClosed: () => context.pop(),
+                          );
+                        },
+                        child: Padding(
+                          padding: const EdgeInsets.all(8.0),
+                          child: Text(
+                            "회원탈퇴",
+                            style: TextStyle(color: AppColors.danger(context)),
                           ),
-                        );
-                      },
-                      child: Padding(
-                        padding: const EdgeInsets.all(8.0),
-                        child: Text(
-                          "회원탈퇴",
-                          style: TextStyle(color: AppColors.danger(context)),
                         ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
-              ],
+              ),
             ),
-          ),
+            ?viewModel.isShowOnboarding
+                ? OnboardingScreen(onFinished: viewModel.toggleOnboarding)
+                : null,
+          ],
         );
       },
     );

--- a/lib/features/profile/presentation/views/widgets/onboarding_button.dart
+++ b/lib/features/profile/presentation/views/widgets/onboarding_button.dart
@@ -2,9 +2,7 @@ import 'package:dutytable/core/configs/app_colors.dart';
 import 'package:dutytable/features/profile/presentation/viewmodels/profile_view_model.dart';
 import 'package:dutytable/features/profile/presentation/widgets/profile_tab.dart';
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 class OnboardingButton extends StatelessWidget {
   const OnboardingButton({super.key});
@@ -15,10 +13,7 @@ class OnboardingButton extends StatelessWidget {
 
     return GestureDetector(
       onTap: () async {
-        final prefs = await SharedPreferences.getInstance();
-        await prefs.setBool("isOnboardingDone", false);
-        viewModel.logout();
-        if (context.mounted) context.push("/login");
+        viewModel.toggleOnboarding();
       },
       child: CustomTab(
         icon: Icons.lightbulb_outline_rounded,

--- a/lib/features/profile/presentation/views/widgets/user_profile_section.dart
+++ b/lib/features/profile/presentation/views/widgets/user_profile_section.dart
@@ -2,8 +2,9 @@ import 'package:dutytable/core/configs/app_colors.dart';
 import 'package:dutytable/features/profile/presentation/viewmodels/profile_view_model.dart';
 import 'package:dutytable/features/profile/presentation/views/widgets/account_section.dart';
 import 'package:flutter/material.dart';
-import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
+
+import '../../../../../core/utils/image_picker_utils.dart';
 
 class UserProfileSection extends StatelessWidget {
   const UserProfileSection({super.key});
@@ -23,7 +24,9 @@ class UserProfileSection extends StatelessWidget {
                 SizedBox(
                   width: 60,
                   height: 60,
-                  child: (viewModel.image == null || viewModel.image!.isEmpty)
+                  child: viewModel.isLoading
+                      ? const Center(child: CircularProgressIndicator())
+                      : (viewModel.image == null || viewModel.image!.isEmpty)
                       ? Icon(
                           Icons.account_circle,
                           size: 60,
@@ -44,9 +47,15 @@ class UserProfileSection extends StatelessWidget {
                     right: 0,
                     bottom: 0,
                     child: GestureDetector(
-                      onTap: () async {
-                        await viewModel.getImage(ImageSource.gallery);
-                        await viewModel.upload();
+                      onTap: () {
+                        ImagePickerUtils.showImagePicker(
+                          context: context,
+                          onImageSelected: (source) async {
+                            await viewModel.pickProfileImage(source);
+                            await viewModel.upload();
+                          },
+                          onDelete: viewModel.deleteImage,
+                        );
                       },
                       child: CircleAvatar(
                         radius: 12,


### PR DESCRIPTION
# 주요내용

## 프로필 화면 온보딩 로직 변경
- 기존 : 로그아웃 후 로그인 화면으로 이동 -> 온보딩 다시 보여주기
- 변경 : 프로필 화면에서 온보딩 보여주기(값은 프로필 뷰모델에서 별도의 값으로 직접 관리)

## 프로필 이미지 선택 로직 변경
- 기존 : 갤러리에서만 선택 가능
- 변경 : 모달 바텀 시트 적용, 업로드 후 이미지 로딩 적용
