### PR TITLE
공유 캘린더 목록 화면 리팩토링

### DIFF
--- a/lib/features/calendar/presentation/views/shared/list/widgets/shared_calendar_body.dart
+++ b/lib/features/calendar/presentation/views/shared/list/widgets/shared_calendar_body.dart
@@ -68,6 +68,8 @@ class _CalendarListItem extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final viewModel = context.read<SharedCalendarViewModel>();
+
     /// 방장인지 여부
     final isAdmin = context.select<SharedCalendarViewModel, bool>(
       (vm) => calendar.userId == vm.currentUserId,
@@ -85,8 +87,20 @@ class _CalendarListItem extends StatelessWidget {
 
     return GestureDetector(
       onTap: () async {
+        if (deleteMode) {
+          if (isAdmin) {
+            // 1. 삭제 모드이면서 방장인 경우: 아무것도 하지 않음 (화면 이동 차단)
+            return;
+          } else {
+            // 2. 삭제 모드이면서 일반 멤버인 경우: 선택 토글만 수행
+            viewModel.toggleSelected(calendar.id.toString());
+            return;
+          }
+        }
+
+        // 3. 일반 모드일 때만 상세 화면으로 이동
         await context.push("/shared/schedule", extra: calendar);
-        context.read<SharedCalendarViewModel>().fetchCalendars();
+        viewModel.fetchCalendars();
       },
       child: CalendarCard(
         imageUrl: calendar.imageURL,

--- a/lib/features/calendar/presentation/widgets/calendar_card.dart
+++ b/lib/features/calendar/presentation/widgets/calendar_card.dart
@@ -105,7 +105,19 @@ class CalendarCard extends StatelessWidget {
   //   가운데 텍스트 정보
   // ------------------------------
   Widget _buildInfoText(BuildContext context) {
-    final viewModel = context.watch<SharedCalendarViewModel>();
+    final int id = calendarId ?? -1;
+
+    // context.select를 사용하여 특정 ID의 데이터만 추출
+    final String month = context.select<SharedCalendarViewModel, String>(
+      (vm) => vm.nextScheduleDateMonth[id] ?? "",
+    );
+    final String day = context.select<SharedCalendarViewModel, String>(
+      (vm) => vm.nextScheduleDateDay[id] ?? "",
+    );
+    final String scheduleTitle = context
+        .select<SharedCalendarViewModel, String>(
+          (vm) => vm.nextScheduleTitle[id] ?? "",
+        );
 
     return Expanded(
       child: Column(
@@ -113,45 +125,38 @@ class CalendarCard extends StatelessWidget {
         children: [
           Row(
             children: [
-              Expanded(
-                child: Text(
-                  title,
-                  style: TextStyle(
-                    fontSize: 14,
-                    fontWeight: FontWeight.w700,
-                    color: AppColors.textMain(context),
-                  ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
+              Text(
+                title,
+                style: TextStyle(
+                  fontSize: 14,
+                  fontWeight: FontWeight.w700,
+                  color: AppColors.textMain(context),
                 ),
               ),
               const SizedBox(width: 8),
               _buildMemberChip(context),
             ],
           ),
-
           const SizedBox(height: 6),
-
           Row(
             children: [
-              Text(
-                "다음 일정 : ${viewModel.nextScheduleDateMonth[calendarId ?? " "]}월 ${viewModel.nextScheduleDateDay[calendarId ?? " "]}일 ",
-                style: TextStyle(
-                  fontSize: 12,
-                  color: AppColors.textSub(context),
-                ),
-              ),
-              const SizedBox(width: 10),
-              Expanded(
-                child: Text(
-                  "${viewModel.nextScheduleTitle[calendarId ?? " "]}",
+              // 데이터가 있을 때만 날짜 표시
+              if (month.isNotEmpty && day.isNotEmpty)
+                Text(
+                  "다음 일정 : ${month}월 ${day}일",
                   style: TextStyle(
                     fontSize: 12,
                     color: AppColors.textSub(context),
                   ),
-                  maxLines: 1,
-                  overflow: TextOverflow.ellipsis,
                 ),
+              Text(
+                scheduleTitle.isEmpty ? "예정된 일정 없음" : " / ${[scheduleTitle]}",
+                style: TextStyle(
+                  fontSize: 12,
+                  color: AppColors.textSub(context),
+                ),
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
               ),
             ],
           ),
@@ -185,22 +190,27 @@ class CalendarCard extends StatelessWidget {
     final viewModel = context.watch<SharedCalendarViewModel>();
     if (!deleteMode) {
       /// 일반 모드 → 알림 표시
-      return Container(
-        width: 42,
-        height: 42,
-        decoration: BoxDecoration(
-          color: AppColors.danger(context),
-          shape: BoxShape.circle,
-        ),
-        alignment: Alignment.center,
-        child: Text(
-          "${viewModel.unreadCount[calendarId ?? 0] ?? 0}",
-          style: TextStyle(
-            color: AppColors.pureWhite,
-            fontWeight: FontWeight.bold,
+      // 새로운 채팅이 있을때만 표시
+      if (viewModel.unreadCount[calendarId ?? 0] != 0) {
+        return Container(
+          width: 42,
+          height: 42,
+          decoration: BoxDecoration(
+            color: AppColors.danger(context),
+            shape: BoxShape.circle,
           ),
-        ),
-      );
+          alignment: Alignment.center,
+          child: Text(
+            "${viewModel.unreadCount[calendarId ?? 0] ?? 0}",
+            style: TextStyle(
+              color: AppColors.pureWhite,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        );
+      } else {
+        return SizedBox(width: 42, height: 42);
+      }
     }
 
     /// deleteMode === true


### PR DESCRIPTION
# 주요내용

- 새로운 채팅 없으면 채팅 UI 표시 안함
- 캘린더 멤버 캘린더 제목 옆으로 이동
- 다음 일정, 안읽은 채팅 가져오는 로직 CalendarDataSource로 리팩토링
- 삭제모드에서 "삭제 불가" 캘린더 클릭시 화면 이동하는 버그 픽스
- 다음 일정 표시 방식 변경(다음 일정 없으면 "예정된 일정 없음"으로 표기)

## 앱 최초 실행시 공유 캘린더 목록에서 null 표시 되는 버그 픽스중(미완료)