### PR TITLE
앱 최초 실행시 공유 캘린더 목록 화면 null 뜨는 버그 픽스

### DIFF
--- a/lib/core/router/app_router.dart
+++ b/lib/core/router/app_router.dart
@@ -1,4 +1,3 @@
-import 'package:dutytable/features/auth/presentation/views/login/login_screen.dart' hide LoginScreen;
 import 'package:dutytable/features/calendar/presentation/views/add/calendar_add_screen.dart';
 import 'package:dutytable/features/calendar/presentation/views/edit/calendar_edit_screen.dart';
 import 'package:dutytable/features/calendar/presentation/views/personal/personal_calendar_screen.dart';
@@ -18,7 +17,6 @@ import '../../features/auth/presentation/views/signup/signup_screen.dart';
 import '../../features/auth/presentation/views/splash_screen.dart';
 import '../../features/calendar/data/models/calendar_model.dart';
 import '../../features/calendar/presentation/viewmodels/personal_calendar_view_model.dart';
-import '../../features/calendar/presentation/viewmodels/shared_calendar_view_model.dart';
 import '../../features/calendar/presentation/views/setting/calendar_setting_screen.dart';
 import '../../features/calendar/presentation/views/shared/list/shared_calendar_list_screen.dart';
 import 'app_shell.dart';
@@ -119,16 +117,7 @@ GoRouter createRouter(BuildContext context) {
           GoRoute(
             path: '/shared',
             builder: (context, state) {
-              Map<String, dynamic>? extraMap;
-              if (state.extra is Map<String, dynamic>) {
-                extraMap = state.extra as Map<String, dynamic>;
-              }
-              final List<CalendarModel>? initialCalendars =
-              extraMap?['sharedCalendars'] as List<CalendarModel>?;
-
-              return SharedCalendarListScreen(
-                initialCalendars: initialCalendars,
-              );
+              return SharedCalendarListScreen();
             },
             routes: [
               GoRoute(

--- a/lib/features/auth/presentation/views/splash_screen.dart
+++ b/lib/features/auth/presentation/views/splash_screen.dart
@@ -72,7 +72,7 @@ class _SplashScreenState extends State<SplashScreen> {
         context.go('/login');
       } else {
         // 인증 및 데이터 로드에 성공하면 메인 화면으로 이동하며 데이터를 전달
-        context.go('/shared', extra: {'sharedCalendars': sharedCalendars});
+        context.go('/shared');
       }
     }
   }

--- a/lib/features/calendar/presentation/viewmodels/shared_calendar_view_model.dart
+++ b/lib/features/calendar/presentation/viewmodels/shared_calendar_view_model.dart
@@ -86,23 +86,12 @@ class SharedCalendarViewModel extends ChangeNotifier {
   }
 
   /// 공유 캘린더 목록 뷰모델
-  SharedCalendarViewModel({
-    List<CalendarModel>? calendarList,
-    CalendarModel? calendar,
-  }) {
+  SharedCalendarViewModel({CalendarModel? calendar}) {
     if (calendar != null) {
       // 5단계 : 데이터 받아서 입력
       _calendar = calendar;
     }
-    if (calendarList != null) {
-      // splash 화면에서 받아온 데이터 있을 때
-      _calendarList = calendarList;
-      _state = ViewState.success;
-    } else {
-      // splash 화면에서 받아온 데이터 없을 때
-      _state = ViewState.loading;
-      fetchCalendars();
-    }
+    fetchCalendars();
   }
 
   Future<void> addInvitedUserByNickname(String nickname) async {
@@ -162,15 +151,6 @@ class SharedCalendarViewModel extends ChangeNotifier {
   void clearError() {
     _inviteError = null;
     notifyListeners();
-  }
-
-  void setInitialData(List<CalendarModel>? initialData) {
-    if (initialData != null && _calendarList == null) {
-      _calendarList = initialData;
-      _state = ViewState.success;
-      // build 단계에서 호출될 수 있으므로 마이크로태스크나 다음 프레임에 알림
-      Future.microtask(() => notifyListeners());
-    }
   }
 
   @override

--- a/lib/features/calendar/presentation/views/shared/list/shared_calendar_list_screen.dart
+++ b/lib/features/calendar/presentation/views/shared/list/shared_calendar_list_screen.dart
@@ -1,26 +1,15 @@
 import 'package:dutytable/core/configs/app_colors.dart';
 import 'package:dutytable/core/widgets/logo_actions_app_bar.dart';
-import 'package:dutytable/features/calendar/data/models/calendar_model.dart';
-import 'package:dutytable/features/calendar/presentation/viewmodels/shared_calendar_view_model.dart';
 import 'package:dutytable/features/calendar/presentation/views/shared/list/widgets/left_actions.dart';
 import 'package:dutytable/features/calendar/presentation/views/shared/list/widgets/right_actions.dart';
 import 'package:dutytable/features/calendar/presentation/views/shared/list/widgets/shared_calendar_body.dart';
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
 
 class SharedCalendarListScreen extends StatelessWidget {
-  final List<CalendarModel>? initialCalendars;
-
-  const SharedCalendarListScreen({super.key, this.initialCalendars});
+  const SharedCalendarListScreen({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final viewModel = context.read<SharedCalendarViewModel>();
-
-    if (initialCalendars != null) {
-      Future.microtask(() => viewModel.setInitialData(initialCalendars!));
-    }
-
     return const _SharedCalendarListScreen();
   }
 }


### PR DESCRIPTION
# 주요내용

## 앱 최초 실행시 공유 캘린더 목록 화면 null 뜨는 버그 픽스
- 스플래시 화면에서 넘겨주는 init 데이터에는 다음 일정, 안읽은 채팅 데이터가 없는게 원인