### PR TITLE
공유 캘린더 목록 화면 버그 픽스

### DIFF
--- a/lib/features/calendar/presentation/widgets/calendar_card.dart
+++ b/lib/features/calendar/presentation/widgets/calendar_card.dart
@@ -125,7 +125,8 @@ class CalendarCard extends StatelessWidget {
         children: [
           Row(
             children: [
-              Expanded(
+              // _buildMemberChip을 무조건 밀어내지 않게 자식의 크기에 맞추는 Flexible 사용
+              Flexible(
                 child: Text(
                   title,
                   style: TextStyle(
@@ -147,7 +148,7 @@ class CalendarCard extends StatelessWidget {
               Expanded(
                 child: Text(
                   (month.isNotEmpty && day.isNotEmpty)
-                      ? "다음 일정 : $month월 $day일 $scheduleTitle"
+                      ? "다음 일정 : $month월 $day일 / ${[scheduleTitle]}"
                       : (scheduleTitle.isEmpty
                             ? "예정된 일정 없음"
                             : "일정 : $scheduleTitle"),

--- a/lib/features/calendar/presentation/widgets/calendar_card.dart
+++ b/lib/features/calendar/presentation/widgets/calendar_card.dart
@@ -125,12 +125,16 @@ class CalendarCard extends StatelessWidget {
         children: [
           Row(
             children: [
-              Text(
-                title,
-                style: TextStyle(
-                  fontSize: 14,
-                  fontWeight: FontWeight.w700,
-                  color: AppColors.textMain(context),
+              Expanded(
+                child: Text(
+                  title,
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.w700,
+                    color: AppColors.textMain(context),
+                  ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
               ),
               const SizedBox(width: 8),

--- a/lib/features/calendar/presentation/widgets/calendar_card.dart
+++ b/lib/features/calendar/presentation/widgets/calendar_card.dart
@@ -140,23 +140,20 @@ class CalendarCard extends StatelessWidget {
           const SizedBox(height: 6),
           Row(
             children: [
-              // 데이터가 있을 때만 날짜 표시
-              if (month.isNotEmpty && day.isNotEmpty)
-                Text(
-                  "다음 일정 : ${month}월 ${day}일",
+              Expanded(
+                child: Text(
+                  (month.isNotEmpty && day.isNotEmpty)
+                      ? "다음 일정 : ${month}월 ${day}일 ${scheduleTitle.isEmpty ? "예정된 일정 없음" : " / $scheduleTitle"}"
+                      : (scheduleTitle.isEmpty
+                            ? "예정된 일정 없음"
+                            : "일정 : $scheduleTitle"),
                   style: TextStyle(
                     fontSize: 12,
                     color: AppColors.textSub(context),
                   ),
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
                 ),
-              Text(
-                scheduleTitle.isEmpty ? "예정된 일정 없음" : " / ${[scheduleTitle]}",
-                style: TextStyle(
-                  fontSize: 12,
-                  color: AppColors.textSub(context),
-                ),
-                maxLines: 1,
-                overflow: TextOverflow.ellipsis,
               ),
             ],
           ),

--- a/lib/features/calendar/presentation/widgets/calendar_card.dart
+++ b/lib/features/calendar/presentation/widgets/calendar_card.dart
@@ -143,7 +143,7 @@ class CalendarCard extends StatelessWidget {
               Expanded(
                 child: Text(
                   (month.isNotEmpty && day.isNotEmpty)
-                      ? "다음 일정 : ${month}월 ${day}일 ${scheduleTitle.isEmpty ? "예정된 일정 없음" : " / $scheduleTitle"}"
+                      ? "다음 일정 : $month월 $day일 $scheduleTitle"
                       : (scheduleTitle.isEmpty
                             ? "예정된 일정 없음"
                             : "일정 : $scheduleTitle"),


### PR DESCRIPTION
# 주요내용

- 공유 캘린더 목록 화면 삭제 모드일 때 다음 일정 부분이 너무 길면 ui overflow 생기는 버그 픽스
![Screenshot_20260107_111443](https://github.com/user-attachments/assets/cbde9b80-45ed-4d3d-8989-5efc5551c614)

![Screenshot_20260107_111457](https://github.com/user-attachments/assets/4a8bafff-d67b-464b-8274-619d4bf0802e)
