### PR TITLE
캘린더 추가, 수정 텍스트 필드 글자 수 제한

### DIFF
--- a/lib/features/calendar/presentation/views/add/widgets/calendar_add_body.dart
+++ b/lib/features/calendar/presentation/views/add/widgets/calendar_add_body.dart
@@ -34,6 +34,7 @@ class CalendarAddBody extends StatelessWidget {
             validator: (value) =>
                 value == null || value.trim().isEmpty ? '캘린더 이름은 필수입니다' : null,
             onChanged: viewModel.setTitle,
+            maxLength: 20,
           ),
 
           const SizedBox(height: 12),
@@ -62,6 +63,7 @@ class CalendarAddBody extends StatelessWidget {
             hint: "캘린더 설명을 입력해주세요 (선택사항)",
             maxLines: 8,
             onChanged: viewModel.setDescription,
+            maxLength: 500,
           ),
         ],
       ),

--- a/lib/features/calendar/presentation/views/edit/widgets/calendar_edit_body.dart
+++ b/lib/features/calendar/presentation/views/edit/widgets/calendar_edit_body.dart
@@ -54,6 +54,8 @@ class CalendarEditBody extends StatelessWidget {
                   ),
                 ),
                 controller: viewModel.titleController,
+                maxLength: 20,
+                maxLines: 1,
               ),
 
               const SizedBox(height: 40),
@@ -73,6 +75,8 @@ class CalendarEditBody extends StatelessWidget {
                   ),
                 ),
                 controller: viewModel.descController,
+                maxLength: 500,
+                maxLines: null,
               ),
             ],
           ),

--- a/lib/features/calendar/presentation/views/edit/widgets/custom_calendar_edit_text_field.dart
+++ b/lib/features/calendar/presentation/views/edit/widgets/custom_calendar_edit_text_field.dart
@@ -5,12 +5,16 @@ class CustomCalendarEditTextField extends StatelessWidget {
   /// 박스 위에 표시할 내용
   final Widget title;
   final TextEditingController controller;
+  final int? maxLines;
+  final int? maxLength;
 
   /// 커스텀 캘린더 수정 텍스트 필드
   const CustomCalendarEditTextField({
     super.key,
     required this.title,
     required this.controller,
+    this.maxLines,
+    this.maxLength,
   });
 
   @override
@@ -24,7 +28,8 @@ class CustomCalendarEditTextField extends StatelessWidget {
         const SizedBox(height: 8),
         TextField(
           minLines: 1,
-          maxLines: null, // 높이 제한 없음
+          maxLines: maxLines, // 높이 제한 없음
+          maxLength: maxLength,
           controller: controller,
           keyboardType: TextInputType.multiline,
           style: TextStyle(color: AppColors.textMain(context)),

--- a/lib/features/calendar/presentation/widgets/label_text_field.dart
+++ b/lib/features/calendar/presentation/widgets/label_text_field.dart
@@ -27,6 +27,8 @@ class LabeledTextField extends StatelessWidget {
 
   final ValueChanged<String>? onChanged;
 
+  final int? maxLength;
+
   /// 라벨 + 텍스트 필드
   const LabeledTextField({
     super.key,
@@ -38,6 +40,7 @@ class LabeledTextField extends StatelessWidget {
     this.readOnly = false,
     this.onTap,
     this.onChanged,
+    this.maxLength,
   });
 
   @override
@@ -60,6 +63,7 @@ class LabeledTextField extends StatelessWidget {
           controller: controller,
           validator: validator,
           maxLines: maxLines,
+          maxLength: maxLength,
           readOnly: readOnly,
           onTap: onTap,
           onChanged: onChanged,


### PR DESCRIPTION
# 주요 내용

## 캘린더 추가 화면 텍스트 필드
- 제목 : 20자
- 설명 : 500자

## 캘린더 수정 화면 텍스트 필드
- 제목 : 20자
- 설명 : 500자