### PR TITLE
autoLogin bug

### DIFF
--- a/lib/features/auth/presentation/viewmodels/login_view_model.dart
+++ b/lib/features/auth/presentation/viewmodels/login_view_model.dart
@@ -138,7 +138,7 @@ class LoginViewModel extends ChangeNotifier {
           margin: const EdgeInsets.only(bottom: 20, left: 20, right: 20),
         ),
       );
-      GoRouter.of(context).go('/splash');
+      GoRouter.of(context).go('/shared');
       return;
     }
 

--- a/lib/features/auth/presentation/viewmodels/splash_view_model.dart
+++ b/lib/features/auth/presentation/viewmodels/splash_view_model.dart
@@ -64,4 +64,18 @@ class SplashViewModel with ChangeNotifier {
       }
     }
   }
+
+  bool _isDisposed = false;
+  @override
+  void dispose() {
+    _isDisposed = true;
+    super.dispose();
+  }
+
+  @override
+  void notifyListeners() {
+    if (!_isDisposed) {
+      super.notifyListeners();
+    }
+  }
 }


### PR DESCRIPTION
### 자동로그인 시 로그인 안넘어가는 에러 해결
### splash 화면 dispose 에러

splash 에러는 낮에 확인했을때는 에러가 안떴는데 제가 가끔 앱을 껐다가 켰을때 앱이 실행이 안돼서 백그라운드에서 종료 후 실행을 하는데 그렇게 하면 에러가 뜨는지 확인할 수가 없어서 로그캣으로 확인해봤는데 로그캣으로는 안떴습니다..! 확인 한번씩만 부탁드리겠습니다..!